### PR TITLE
Add websocket log streaming and log file API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,20 +62,25 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-websocket</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>ch.qos.logback</groupId>
-					<artifactId>logback-classic</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>ch.qos.logback</groupId>
-					<artifactId>logback-core</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-websocket</artifactId>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>ch.qos.logback</groupId>
+                                        <artifactId>logback-classic</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>ch.qos.logback</groupId>
+                                        <artifactId>logback-core</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.data</groupId>
+                        <artifactId>spring-data-commons</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/ocoelho/config/WebSocketConfig.java
+++ b/src/main/java/com/ocoelho/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.ocoelho.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/src/main/java/com/ocoelho/controller/LogController.java
+++ b/src/main/java/com/ocoelho/controller/LogController.java
@@ -1,0 +1,49 @@
+package com.ocoelho.controller;
+
+import com.ocoelho.dto.LogFileDto;
+import com.ocoelho.service.LogService;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@RestController
+@RequestMapping("/logs")
+public class LogController {
+
+    private final LogService logService;
+
+    public LogController(LogService logService) {
+        this.logService = logService;
+    }
+
+    @GetMapping
+    public Page<LogFileDto> list(@RequestParam(defaultValue = "0") int page,
+                                 @RequestParam(defaultValue = "10") int size) throws IOException {
+        return logService.list(page, size);
+    }
+
+    @GetMapping("/{fileName:.+}")
+    public ResponseEntity<Resource> download(@PathVariable String fileName) throws IOException {
+        Path file = logService.resolve(fileName);
+        if (Files.notExists(file)) {
+            return ResponseEntity.notFound().build();
+        }
+        Resource resource = new InputStreamResource(Files.newInputStream(file));
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFileName() + "\"")
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
+    }
+}

--- a/src/main/java/com/ocoelho/dto/LogFileDto.java
+++ b/src/main/java/com/ocoelho/dto/LogFileDto.java
@@ -1,0 +1,5 @@
+package com.ocoelho.dto;
+
+import java.time.Instant;
+
+public record LogFileDto(String name, long size, Instant lastModified) {}

--- a/src/main/java/com/ocoelho/service/LogService.java
+++ b/src/main/java/com/ocoelho/service/LogService.java
@@ -1,0 +1,58 @@
+package com.ocoelho.service;
+
+import com.ocoelho.dto.LogFileDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class LogService {
+
+    private final Path logDir = Paths.get("log");
+
+    public Page<LogFileDto> list(int page, int size) throws IOException {
+        if (Files.notExists(logDir)) {
+            return Page.empty(PageRequest.of(page, size));
+        }
+
+        List<LogFileDto> files = Files.list(logDir)
+                .filter(Files::isRegularFile)
+                .map(p -> {
+                    try {
+                        return new LogFileDto(
+                                p.getFileName().toString(),
+                                Files.size(p),
+                                Files.getLastModifiedTime(p).toInstant()
+                        );
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .filter(f -> f != null)
+                .sorted(Comparator.comparing(LogFileDto::lastModified).reversed())
+                .collect(Collectors.toList());
+
+        int from = Math.min(page * size, files.size());
+        int to = Math.min(from + size, files.size());
+        List<LogFileDto> pageContent = files.subList(from, to);
+        return new PageImpl<>(pageContent, PageRequest.of(page, size), files.size());
+    }
+
+    public Path resolve(String filename) {
+        Path file = logDir.resolve(filename).normalize();
+        if (!file.startsWith(logDir)) {
+            throw new IllegalArgumentException("Invalid file path");
+        }
+        return file;
+    }
+}

--- a/src/main/java/com/ocoelho/service/LogTailService.java
+++ b/src/main/java/com/ocoelho/service/LogTailService.java
@@ -1,0 +1,48 @@
+package com.ocoelho.service;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+public class LogTailService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final Path logFile = Paths.get("log/application.log");
+    private long filePointer = 0L;
+
+    public LogTailService(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @PostConstruct
+    public void init() throws IOException {
+        if (Files.notExists(logFile)) {
+            Files.createDirectories(logFile.getParent());
+            Files.createFile(logFile);
+        }
+        filePointer = Files.size(logFile);
+    }
+
+    @Scheduled(fixedDelay = 1000)
+    public void tailLogFile() throws IOException {
+        long fileSize = Files.size(logFile);
+        if (fileSize > filePointer) {
+            try (RandomAccessFile file = new RandomAccessFile(logFile.toFile(), "r")) {
+                file.seek(filePointer);
+                String line;
+                while ((line = file.readLine()) != null) {
+                    messagingTemplate.convertAndSend("/topic/logs", line);
+                }
+                filePointer = file.getFilePointer();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- configure STOMP websocket endpoint and simple broker
- tail application log file and broadcast new lines to `/topic/logs`
- expose `/logs` REST API to list and download log files
- add Spring Data commons dependency for pagination support

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2305bb308328bed6a86eb556ab8a