### PR TITLE
Fix bean name conflict in WebSocket configuration

### DIFF
--- a/src/main/java/com/ocoelho/webscoket/LogWebSocketConfig.java
+++ b/src/main/java/com/ocoelho/webscoket/LogWebSocketConfig.java
@@ -9,12 +9,12 @@ import com.ocoelho.properties.AppLoggingProperties;
 
 @Configuration
 @EnableWebSocket
-public class WebSocketConfig implements WebSocketConfigurer {
+public class LogWebSocketConfig implements WebSocketConfigurer {
 
     private final LogStreamWebSocketHandler logStreamWebSocketHandler;
     private final AppLoggingProperties appLoggingProperties;
 
-    public WebSocketConfig(LogStreamWebSocketHandler logStreamWebSocketHandler, AppLoggingProperties appLoggingProperties) {
+    public LogWebSocketConfig(LogStreamWebSocketHandler logStreamWebSocketHandler, AppLoggingProperties appLoggingProperties) {
         this.logStreamWebSocketHandler = logStreamWebSocketHandler;
         this.appLoggingProperties = appLoggingProperties;
     }


### PR DESCRIPTION
## Summary
- rename log WebSocket configuration class to avoid duplicate bean name

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2d202e20832894e6dc8e3db7dd96