### PR TITLE
Enable WebSocket log streaming and unify log directory

### DIFF
--- a/src/main/java/com/ocoelho/service/LogService.java
+++ b/src/main/java/com/ocoelho/service/LogService.java
@@ -3,7 +3,6 @@ package com.ocoelho.service;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,11 +13,16 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import com.ocoelho.dto.LogFileDto;
+import com.ocoelho.properties.AppLoggingProperties;
 
 @Service
 public class LogService {
 
-    private final Path logDir = Paths.get("log");
+    private final Path logDir;
+
+    public LogService(AppLoggingProperties properties) {
+        this.logDir = properties.getDir();
+    }
 
     public Page<LogFileDto> list(int page, int size) throws IOException {
         if (Files.notExists(logDir)) {

--- a/src/main/java/com/ocoelho/service/LogTailService.java
+++ b/src/main/java/com/ocoelho/service/LogTailService.java
@@ -14,7 +14,7 @@ import jakarta.annotation.PostConstruct;
 public class LogTailService {
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final Path logFile = Paths.get("log/application.log");
+    private final Path logFile = Paths.get("logs/application.log");
     private long filePointer = 0L;
 
     public LogTailService(SimpMessagingTemplate messagingTemplate) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,32 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="DEBUG">
+<Configuration status="DEBUG" packages="com.ocoelho.webscoket">
 	<Properties>
 		<Property name="applicationName">application</Property>
-		<Property name="logPath">log</Property>
+                <Property name="logPath">logs</Property>
 		<Property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} | %-5level | PID[%pid] | Th[%thread] - Cl[%c{1}] > %msg%n</Property>
 		<Property name="logPattern">%d{yyyy-MM-dd HH:mm:ss.SSS} | %-5level | PID[%pid] | Th[%thread] - Cl[%c{1}] > %msg%n</Property>
 	</Properties>
 
-	<Appenders>
-		<Console name="LogToConsole" target="SYSTEM_OUT">
-			<PatternLayout pattern="${pattern}" />
-		</Console>
+        <Appenders>
+                <Console name="LogToConsole" target="SYSTEM_OUT">
+                        <PatternLayout pattern="${pattern}" />
+                </Console>
 
-		<RollingFile name="RollingFileAppender" fileName="${logPath}/${applicationName}.log" filePattern="${logPath}/archive/${applicationName}-%d{yyyy-MM-dd}-%i.log.gz" createOnDemand="true">
-			<PatternLayout pattern="${logPattern}" />
-			<Policies>
-				<TimeBasedTriggeringPolicy interval="1" modulate="true" />
-				<SizeBasedTriggeringPolicy size="50MB" />
-			</Policies>
-			<DefaultRolloverStrategy max="30" />
-		</RollingFile>
-	</Appenders>
+                <RollingFile name="RollingFileAppender" fileName="${logPath}/${applicationName}.log" filePattern="${logPath}/archive/${applicationName}-%d{yyyy-MM-dd}-%i.log.gz" createOnDemand="true">
+                        <PatternLayout pattern="${logPattern}" />
+                        <Policies>
+                                <TimeBasedTriggeringPolicy interval="1" modulate="true" />
+                                <SizeBasedTriggeringPolicy size="50MB" />
+                        </Policies>
+                        <DefaultRolloverStrategy max="30" />
+                </RollingFile>
+
+                <WebSocketAppender name="WebSocketAppender">
+                        <PatternLayout pattern="${logPattern}" />
+                </WebSocketAppender>
+        </Appenders>
 
 	<Loggers>
-		<Root level="INFO">
-			<!-- Os refs PRECISAM bater com os 'name' lá em cima -->
-			<AppenderRef ref="LogToConsole" />
-			<AppenderRef ref="RollingFileAppender" />
-		</Root>
-	</Loggers>
+                <Root level="INFO">
+                        <!-- Os refs PRECISAM bater com os 'name' lá em cima -->
+                        <AppenderRef ref="LogToConsole" />
+                        <AppenderRef ref="RollingFileAppender" />
+                        <AppenderRef ref="WebSocketAppender" />
+                </Root>
+        </Loggers>
 </Configuration>


### PR DESCRIPTION
## Summary
- Load custom Log4j2 appender package and broadcast logs over WebSocket
- Store log files under configurable `logs` directory and inject location via `AppLoggingProperties`
- Align tail service to new logs path

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a2fcd92d88328bb0bf4438ead653d